### PR TITLE
Xtra commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ To see the players in a clan, run the following command:
 /mw clan members list <cows | sheep>
 ```
 
+For players to know which clan they're joining, placing the clan treasure heads is very simple. To obtain them, run the following command:
+```
+/mw clan gethead <cows | sheep> <active | inactive>
+```
+
 ### Promoting and demoting clan leaders
 
 To help run the game smoother and take some responsibility from the admins, clans can have their own _clan leaders_ that can manage their clan. To make someone a leader of their clan or revoke their leader status, do one the following commands:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Your most important role as a clan leader is to manage your clan's treasure. the
 ```
 This sets the respawn point of the treasure and teleports it to you. Your location becomes the home point of the treasure, and should be in _a visible and well-lit area of your clan hall._ Players shouldn't have to break blocks to get to it! As a clan leader it's your responsibility to make your clan's treasure actually accessible to the enemies to make it fun and enjoyable for everyone. 10 layers of obsidian? No! A fun and challenging parkour to get to the treasure? Perfect!
 
+While we're on the subject of your clan hall, your clan members need to be able to sign in and out at it. Use the following command to spawn command blocks that do only this:
+```
+/clan setcommandblock <signin | signout>
+```
+
 If for some reason the treasure gets destroyed (which should be impossible for survival players) or lost, you can run the following command. Note that the treasure automatically respawns after 24 hours back at its home location, so you should rarely (if ever) need to run this command:
 ```
 /clan treasure setlocation

--- a/src/com/hiuni/milkwars/Clan.java
+++ b/src/com/hiuni/milkwars/Clan.java
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPI;
 import org.apache.commons.lang.ObjectUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 
@@ -24,6 +25,9 @@ public class Clan {
     private int kills; // A counter for how many times clan members have killed other clam members.
     private int captures; // A counter for how many times the clan has successfully captured the enemy flag.
     private Flag flag;
+
+    private Location signInCommandBlock;
+    private Location signOutCommandBlock;
 
     Clan(int clanId, String name, String prefix) {
 
@@ -218,6 +222,24 @@ public class Clan {
         return this.flag;
     }
 
+    public Location getSignInCommandBlock() {
+        return signInCommandBlock;
+    }
+
+    public Location getSignOutCommandBlock() {
+        return signOutCommandBlock;
+    }
+
+    public void setSignInCommandBlock(Location location) {
+        signInCommandBlock = location;
+        DataManager.registerChanges();
+    }
+
+    public void setSignOutCommandBlock(Location location) {
+        signOutCommandBlock = location;
+        DataManager.registerChanges();
+    }
+
     public void save(FileConfiguration config, String keyPath) {
         // Saves the clan data to file so that it can preserved when the server restarts.
         //config.set(keyPath + ".name", getName());
@@ -231,6 +253,9 @@ public class Clan {
             member.save(config, keyPath + ".members");
         }
         flag.save(config, keyPath + ".flag");
+
+        config.set(keyPath + ".commandblocks.signin", signInCommandBlock);
+        config.set(keyPath + ".commandblocks.signout", signOutCommandBlock);
     }
 
     public void load(FileConfiguration config, String keyPath) {
@@ -247,6 +272,9 @@ public class Clan {
         //this.prefix = config.getString(keyPath + ".prefix");
 
         flag.load(config, keyPath + ".flag");
+
+        signInCommandBlock = config.getLocation(keyPath + ".commandblocks.signin");
+        signOutCommandBlock = config.getLocation(keyPath + ".commandblocks.signout");
 
         this.members.clear();
         try {

--- a/src/com/hiuni/milkwars/Flag.java
+++ b/src/com/hiuni/milkwars/Flag.java
@@ -137,7 +137,7 @@ public class Flag implements Listener {
         // If we can find it, it's much easier.
         Entity ent = Bukkit.getServer().getEntity(flagId);
         if (ent != null) {
-            ((ArmorStand) ent).getEquipment().setHelmet(getHead());
+            ((ArmorStand) ent).getEquipment().setHelmet(getHead(clanId, active));
         }
         else {
             // Teleport the flag to itself.
@@ -472,7 +472,7 @@ public class Flag implements Listener {
         ArmorStand stand = (ArmorStand) Bukkit.getWorld("world").spawnEntity(location, EntityType.ARMOR_STAND);
 
         // Set the helmet of the armor stand to a specific player head
-        stand.getEquipment().setHelmet(getHead());
+        stand.getEquipment().setHelmet(getHead(clanId, active));
 
         stand.setCustomName(getEntityName());
 
@@ -490,11 +490,10 @@ public class Flag implements Listener {
     Generates the player head item for the flag.
     The specific skin to use depends on what clan the flag is in and if it's active or not.
      */
-    private ItemStack getHead() {
+    public static ItemStack getHead(int clanId, boolean active) {
         String head = HEADS[clanId][active ? 1 : 0];
         String url = "http://textures.minecraft.net/texture/" + head;
-        ItemStack stack = SkullCreator.itemFromUrl(url);
-        return stack;
+        return SkullCreator.itemFromUrl(url);
     }
 
     /*

--- a/src/com/hiuni/milkwars/commands/CommandManager.java
+++ b/src/com/hiuni/milkwars/commands/CommandManager.java
@@ -3,6 +3,7 @@ package com.hiuni.milkwars.commands;
 import com.hiuni.milkwars.Clan;
 import com.hiuni.milkwars.MilkWars;
 import com.hiuni.milkwars.commands.subcommands.ClanCommand;
+import com.hiuni.milkwars.commands.subcommands.SetCommandBlockCommand;
 import com.hiuni.milkwars.commands.subcommands.SettingsCommand;
 import com.hiuni.milkwars.commands.subcommands.TreasureCommand;
 import dev.jorel.commandapi.CommandAPICommand;
@@ -33,6 +34,7 @@ public class CommandManager {
                 }))
                 .withSubcommand(new TreasureCommand().getLeadersCommand())
                 .withSubcommand(new ClanCommand().getLeadersMembersCommand())
+                .withSubcommand(new SetCommandBlockCommand().getLeadersCommand())
                 .register();
     }
 }

--- a/src/com/hiuni/milkwars/commands/subcommands/ClanCommand.java
+++ b/src/com/hiuni/milkwars/commands/subcommands/ClanCommand.java
@@ -2,6 +2,7 @@ package com.hiuni.milkwars.commands.subcommands;
 
 import com.hiuni.milkwars.Clan;
 import com.hiuni.milkwars.ClanMember;
+import com.hiuni.milkwars.Flag;
 import com.hiuni.milkwars.MilkWars;
 import dev.jorel.commandapi.CommandAPI;
 import dev.jorel.commandapi.CommandAPICommand;
@@ -12,6 +13,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 
 import java.text.Collator;
 import java.util.Collection;
@@ -313,10 +315,37 @@ public class ClanCommand {
                 CommandAPI.fail("Player isn't a part of a clan!");
             });
 
+    private final CommandAPICommand clanGetHead = new CommandAPICommand("gethead")
+            .withArguments(new MultiLiteralArgument("cows", "sheep"))
+            .withArguments(new MultiLiteralArgument("active", "inactive"))
+            .executesPlayer((player, args) -> {
+                int clanIndex = 0;
+                switch ((String) args[0]) {
+                    case "cows" -> clanIndex = 0;
+                    case "sheep" -> clanIndex = 1;
+                }
+                Clan clan = MilkWars.clans[clanIndex];
+
+                boolean active = args[1].equals("active");
+
+                ItemStack head = Flag.getHead(clanIndex, active);
+
+                boolean accepted = player.getInventory().addItem(head).size() == 0;
+                if (accepted) {
+                    player.sendMessage(
+                            String.format(ChatColor.GREEN + "Got an %s %s head!", args[1], clan.getName())
+                    );
+                }
+                else {
+                    CommandAPI.fail("Your inventory is full!");
+                }
+            });
+
     public CommandAPICommand getCommand() {
         return new CommandAPICommand("clan")
                 .withSubcommand(clanJoin)
                 .withSubcommand(clanLeave)
+                .withSubcommand(clanGetHead)
                 .withSubcommand(new CommandAPICommand("members")
                         .withSubcommand(membersList)
                         .withSubcommand(membersPromote)

--- a/src/com/hiuni/milkwars/commands/subcommands/SetCommandBlockCommand.java
+++ b/src/com/hiuni/milkwars/commands/subcommands/SetCommandBlockCommand.java
@@ -1,0 +1,66 @@
+package com.hiuni.milkwars.commands.subcommands;
+
+import com.hiuni.milkwars.Clan;
+import com.hiuni.milkwars.DataManager;
+import com.hiuni.milkwars.MilkWars;
+import dev.jorel.commandapi.CommandAPI;
+import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.MultiLiteralArgument;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.CommandBlock;
+import org.bukkit.entity.Player;
+
+import java.util.Objects;
+
+public class SetCommandBlockCommand {
+    public CommandAPICommand getLeadersCommand() {
+        return new CommandAPICommand("setcommandblock")
+                .withArguments(new MultiLiteralArgument("signin", "signout"))
+                .executesPlayer((player, args) -> {
+
+                    // The player is a leader, so we know they're in a clan
+                    for (Clan clan: MilkWars.clans) {
+                        if (clan.hasLeader(player)) {
+                            Location location = player.getLocation();
+
+                            if (!Objects.equals(location.getWorld(), Bukkit.getServer().getWorld("world"))) {
+                                CommandAPI.fail("You can only spawn command blocks in the overworld!");
+                                return;
+                            }
+
+                            // Firstly we want to delete the previous command block, if one existed
+                            Location prevLocation;
+                            if (((String) args[0]).equals("signin")) {
+                                prevLocation = clan.getSignInCommandBlock();
+                            }
+                            else {
+                                prevLocation = clan.getSignOutCommandBlock();
+                            }
+                            if (prevLocation != null) {
+                                prevLocation.getBlock().setType(Material.AIR);
+                            }
+
+                            // Now we set the new location
+                            if (((String) args[0]).equals("signin")) {
+                                clan.setSignInCommandBlock(location);
+                            }
+                            else {
+                                clan.setSignOutCommandBlock(location);
+                            }
+                            location.getBlock().setType(Material.COMMAND_BLOCK);
+                            CommandBlock block = (CommandBlock) location.getBlock().getState();
+                            block.setCommand("mw clan members " + (String) args[0] + " @p");
+                            block.update();
+
+                            player.sendMessage(ChatColor.GREEN + "Spawned command block!");
+                            return;
+
+                        }
+                    }
+                    CommandAPI.fail("Something's gone wrong!");
+                });
+    }
+}


### PR DESCRIPTION
Added two commands:
1. `/clan setcommandblock <signin | signout>` - this command lets leaders of a clan spawn in the command blocks at their clan hall for their clan members to sign in and out at, to eliminate admins needing to come in and help
2. `/mw clan gethead <cows | sheep> <active | inactive>` - just a simple command for admins to get a head item from a clan for decoration purposes