### PR TITLE
Glow effect on pickup

### DIFF
--- a/src/com/hiuni/milkwars/Flag.java
+++ b/src/com/hiuni/milkwars/Flag.java
@@ -17,6 +17,8 @@ import org.bukkit.event.player.*;
 import org.bukkit.event.world.EntitiesLoadEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.scheduler.BukkitScheduler;
 
 import java.util.Calendar;
@@ -294,6 +296,15 @@ public class Flag implements Listener {
                         Clan otherClan = MilkWars.clans[(clan.getClanId() + 1) % 2]; // It's hacky af, but I don't care.
                         Announce.sendToAll(player.getDisplayName() + " has picked up the " + otherClan.getName() + " treasure!",
                                 ChatColor.YELLOW);
+
+                        player.addPotionEffect(new PotionEffect(
+                                PotionEffectType.GLOWING,
+                                20*60*3, // The duration in ticks, there are 20 ticks per second, so this should apply for 3 minutes.
+                                0,
+                                false,
+                                false
+                        ));
+
                         }
                     else {
                         player.sendMessage(

--- a/src/com/hiuni/milkwars/MilkWars.java
+++ b/src/com/hiuni/milkwars/MilkWars.java
@@ -2,6 +2,7 @@ package com.hiuni.milkwars;
 
 import com.hiuni.milkwars.commands.CommandManager;
 import com.hiuni.milkwars.events.ClanKillCounterEvent;
+import com.hiuni.milkwars.events.PlayerConsumeEvent;
 import com.hiuni.milkwars.events.SaveOnWorldSave;
 import com.hiuni.milkwars.events.SignCreateEvent;
 import dev.jorel.commandapi.CommandAPI;
@@ -60,6 +61,9 @@ public class MilkWars extends JavaPlugin {
 
         // Register the sign event listener.
         getServer().getPluginManager().registerEvents(new SignCreateEvent(), this);
+
+        // Register the item consume listener.
+        getServer().getPluginManager().registerEvents(new PlayerConsumeEvent(), this);
 
         getServer().getConsoleSender().sendMessage(ChatColor.GREEN + "[Milk-Wars] Plugin has been successfully enabled!");
     }

--- a/src/com/hiuni/milkwars/events/PlayerConsumeEvent.java
+++ b/src/com/hiuni/milkwars/events/PlayerConsumeEvent.java
@@ -1,0 +1,30 @@
+package com.hiuni.milkwars.events;
+
+import com.hiuni.milkwars.Clan;
+import com.hiuni.milkwars.MilkWars;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerItemConsumeEvent;
+
+import java.util.UUID;
+
+public class PlayerConsumeEvent implements Listener {
+    @EventHandler
+    public static void onPlayerConsume(PlayerItemConsumeEvent event) {
+
+        if (event.getItem().getType().equals(Material.MILK_BUCKET)) {
+            // The player drank milk.
+            Player player = event.getPlayer();
+            for (Clan c : MilkWars.clans) {
+                UUID flagBearer = c.getFlag().getWearer();
+                if (flagBearer != null && flagBearer.equals(player.getUniqueId())) {
+                    // Player is carrying a flag.
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/com/hiuni/milkwars/events/PlayerConsumeEvent.java
+++ b/src/com/hiuni/milkwars/events/PlayerConsumeEvent.java
@@ -2,6 +2,7 @@ package com.hiuni.milkwars.events;
 
 import com.hiuni.milkwars.Clan;
 import com.hiuni.milkwars.MilkWars;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -13,7 +14,6 @@ import java.util.UUID;
 public class PlayerConsumeEvent implements Listener {
     @EventHandler
     public static void onPlayerConsume(PlayerItemConsumeEvent event) {
-
         if (event.getItem().getType().equals(Material.MILK_BUCKET)) {
             // The player drank milk.
             Player player = event.getPlayer();
@@ -22,6 +22,7 @@ public class PlayerConsumeEvent implements Listener {
                 if (flagBearer != null && flagBearer.equals(player.getUniqueId())) {
                     // Player is carrying a flag.
                     event.setCancelled(true);
+                    player.sendMessage(ChatColor.YELLOW + "[Milk-wars] You may not drink milk while carrying the flag");
                     return;
                 }
             }


### PR DESCRIPTION
When a player picks up the treasure they get the glow effect for 3 minutes.
players are also unable to drink milk when holding the flag.
fixes #28 